### PR TITLE
QSP-3 Missing Input Validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ Allowance double-spend exploit is mitigated in this contract with functions `inc
 
 However, community agreement on an ERC standard that would protect against this exploit is still pending. Users should be aware of this exploit when interacting with this contract. Developers who use `approve()`/`transferFrom()` should keep in mind that they have to set allowance to 0 first and verify if it was used before setting the new value.
 
+### Ownable
+
+The contract `Governance.sol` uses ownable pattern and has a function `owner()` to report the address with special privileges. Currently, the owner only receives all the initial supply tokens, and there are no additional functionalities associated with the ownable pattern. That may change in the future versions of the contract. The contract owner must be non-zero or the deployment will be reverted.
+
 ### Mint
 
 The function `mint()` is used only during the `initialize()` to mint a fixed amount of tokens. Because of a requirement of the proxy-based upgradability system, no constructors can be used in upgradable contracts. This means that a typically named `initialize()` function has to be used instead and it can be called only once.

--- a/contracts/Governance.sol
+++ b/contracts/Governance.sol
@@ -13,23 +13,24 @@ contract Governance is Initializable, OwnableUpgradeable, ERC20Upgradeable {
     event TokenLocked(address indexed account, uint256 amount);
     event TokenUnlocked(address indexed account, uint256 amount);
 
+    /**
+     * @dev initialize function is used instead of constructors because
+     *      no constructors can be used in upgradable contracts
+     * @param name_ name of the token
+     * @param symbol_ symbol of the token
+     * @param initialSupply_ amount of tokens to be minted and transfered to {owner}
+     * @param owner_ contract owner, must be non-zero
+     */
     function initialize(
         string memory name_,
         string memory symbol_,
         uint256 initialSupply_,
         address owner_
     ) public virtual initializer {
+        require(owner_ != address(0), "Owner must be non-zero address");
         __Governance_init(name_, symbol_, initialSupply_, owner_);
     }
 
-    /**
-     * @dev init function is used instead of constructors because
-     *      no constructors can be used in upgradable contracts
-     * @param name_ name of the token
-     * @param symbol_ symbol of the token
-     * @param initialSupply_ amount of tokens to be minted and transfered to {owner}
-     * @param owner_ smart contract owner
-     */
     function __Governance_init(
         string memory name_,
         string memory symbol_,
@@ -42,11 +43,6 @@ contract Governance is Initializable, OwnableUpgradeable, ERC20Upgradeable {
         __Governance_init_unchained(initialSupply_, owner_);
     }
 
-    /**
-     * @dev mints {initialSupply} amount of token for {owner}
-     * @param initialSupply_ amount of tokens to be minted for {owner}
-     * @param owner_ smart contract owner
-     */
     function __Governance_init_unchained(uint256 initialSupply_, address owner_) internal initializer {
         _mint(owner_, initialSupply_);
     }

--- a/test/Governance.spec.ts
+++ b/test/Governance.spec.ts
@@ -1,6 +1,6 @@
 import { ethers, upgrades } from 'hardhat'
 
-import { expect, getSigners, INITIAL_SUPPLY, NAME, SYMBOL } from './shared'
+import { expect, getSigners, INITIAL_SUPPLY, NAME, SYMBOL, ZERO_ADDRESS } from './shared'
 import { Signers } from './types'
 import { Governance } from '../typechain'
 
@@ -29,6 +29,14 @@ describe('Governance', async () => {
   })
 
   describe('ERC20', () => {
+    it('reverts if initialize() called when owner is zero address', async () => {
+      const GovernanceContract = await ethers.getContractFactory('Governance')
+      // expect to revert when passed zero address
+      await expect(upgrades.deployProxy(GovernanceContract, [NAME, SYMBOL, INITIAL_SUPPLY, ZERO_ADDRESS], {
+        initializer: 'initialize',
+      })).to.be.revertedWith('Owner must be non-zero address')
+    })
+
     it('has correct name', async () => {
       expect(await token.name()).to.equal(NAME)
     })

--- a/test/shared.ts
+++ b/test/shared.ts
@@ -8,6 +8,7 @@ export { expect }
 export const INITIAL_SUPPLY = 1_000_000
 export const NAME = 'Governance'
 export const SYMBOL = 'SGOV'
+export const ZERO_ADDRESS = ethers.constants.AddressZero
 
 export const getSigners = async (): Promise<Signers> => {
   const [OWNER, USER1, USER2] = await ethers.getSigners()


### PR DESCRIPTION
Disallow non-zero owner address in `initialize` function.