### PR TITLE
QSP-5 Greedy Contract

### DIFF
--- a/contracts/Governance.sol
+++ b/contracts/Governance.sol
@@ -103,12 +103,15 @@ contract Governance is Initializable, OwnableUpgradeable, ERC20Upgradeable {
     /**
      * @dev The only difference from standard ERC20 ``transfer()`` is that
      *      it only succeeds if the user has enough unlocked tokens
+     *      and, following best practices, prevent transferal of tokens
+     *      to the contract itself.
      * @param recipient address of the recipient
      * @param amount specified amount of tokens to be transferred
      * @return success status of the transferring
      */
     function transfer(address recipient, uint256 amount) public override returns (bool) {
         require(unlockedBalanceOf(_msgSender()) >= amount, "Governance: Not enough unlocked token balance");
+        require(recipient != address(this), "Governance: Transfers to the contract not allowed");
         return super.transfer(recipient, amount);
     }
 

--- a/test/Governance.spec.ts
+++ b/test/Governance.spec.ts
@@ -95,6 +95,12 @@ describe('Governance', async () => {
   })
 
   describe('Transfers', () => {
+    it('reverts when transfering to the contract', async () => {
+      // expect to revert accidential transfers to the contract itself
+      await expect(token.connect(signers.user1.signer).transfer(token.address, 100))
+        .to.be.revertedWith('Governance: Transfers to the contract not allowed')
+    })
+
     it('sends transfer successfully', async () => {
       // no locked tokens initially
       expect(await token.lockedBalanceOf(signers.user2.address)).to.equal(0)


### PR DESCRIPTION
Prevents from transferring the tokens to the contract.