### PR TITLE
QSP-6 Gas Usage / for Loop Concerns

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The function `mint()` is used only during the `initialize()` to mint a fixed amo
 
 ### Transferring in batch
 
-Anyone can call the method `transfers()` to perform multiple transferring in a single function call.
+Anyone can call the method `transfers()` to perform multiple transferring in a single function call. Homever this is mainly used by the owner/company to distribute the tokens in batch. Normal users are discouraged from executing this function, because arrays with a very large number of elements could cause this function to revert due to exceeding the block size during execution.
 
 ```solidity
 function transfers(

--- a/contracts/Governance.sol
+++ b/contracts/Governance.sol
@@ -103,6 +103,8 @@ contract Governance is Initializable, OwnableUpgradeable, ERC20Upgradeable {
 
     /**
      * @dev Transfers tokens in batch
+     *      Arrays with a very large number of elements could cause this function
+     *      to revert due to exceeding the block size during execution.
      * @param recipients an array of recipient addresses
      * @param values an array of specified amount of tokens to be transferred
      * @return success status of the batch transferring


### PR DESCRIPTION
Adds readme note and contract code comment about `transfers()` and its potential issue with sending too many elements in the arrays of `recipients`/`values`.